### PR TITLE
Update arrays-and-slices.md

### DIFF
--- a/zh-CN/arrays-and-slices.md
+++ b/zh-CN/arrays-and-slices.md
@@ -303,7 +303,7 @@ func TestSumAll(t *testing.T) {
 }
 ```
 
-这里我们尝试比较 `slice` 和 `string`。这显然是不合理的，但是却通过了测试！所以使用 `reflect.DeepEqual` 比较简洁但是在使用时需多加小心。
+这里我们尝试比较 `slice` 和 `string`。这显然是不合理的，但是却通过了编译！所以使用 `reflect.DeepEqual` 比较简洁但是在使用时需多加小心。
 
 回到我们的测试中。运行测试会得到以下信息：
 


### PR DESCRIPTION
### 原文

ref: https://github.com/quii/learn-go-with-tests/blob/master/arrays-and-slices.md

It's important to note that `reflect.DeepEqual` is not "type safe", the code
will compile even if you did something a bit silly. To see this in action,
temporarily change the test to:

```go
func TestSumAll(t *testing.T) {

    got := SumAll([]int{1,2}, []int{0,9})
    want := "bob"

    if !reflect.DeepEqual(got, want) {
        t.Errorf("got %v want %v", got, want)
    }
}
```

What we have done here is try to compare a `slice` with a `string`. Which makes
no sense, but the **test compiles!**  So while using `reflect.DeepEqual` is
a convenient way of comparing slices \(and other things\) you must be careful
when using it.
